### PR TITLE
fixes some issues introduced by newer versions of pandas in Snowflake

### DIFF
--- a/models/marts/ml/prep/covariate_encoding.py
+++ b/models/marts/ml/prep/covariate_encoding.py
@@ -36,8 +36,9 @@ def model(dbt, session):
           return 2
 
   # we are dropping the columns that we filtered on in addition to our training variable
-  encoded_data = fil_cov.drop(['ACTIVE_DRIVER','ACTIVE_CONSTRUCTOR'],1)
-  encoded_data['POSITION_LABEL']= encoded_data['POSITION'].apply(lambda x: position_index(x))
-  encoded_data_grouped_target = encoded_data.drop(['POSITION'],1)
+  encoded_data = fil_cov.drop(['ACTIVE_DRIVER','ACTIVE_CONSTRUCTOR'], axis=1)
+  encoded_data['POSITION_LABEL'] = encoded_data['POSITION'].apply(lambda x: position_index(x))
+  encoded_data_grouped_target = encoded_data.drop(['POSITION'], axis=1)
+
 
   return encoded_data_grouped_target

--- a/models/marts/ml/prep/ml_data_prep.py
+++ b/models/marts/ml/prep/ml_data_prep.py
@@ -25,13 +25,13 @@ def model(dbt, session):
     data['CONSTRUCTOR_NAME'].replace(mapping, inplace=True)
 
     # create confidence metrics for drivers and constructors
-    dnf_by_driver = data.groupby('DRIVER').sum()['DNF_FLAG']
+    dnf_by_driver = data.groupby('DRIVER').sum(numeric_only=True)['DNF_FLAG']
     driver_race_entered = data.groupby('DRIVER').count()['DNF_FLAG']
     driver_dnf_ratio = (dnf_by_driver/driver_race_entered)
     driver_confidence = 1-driver_dnf_ratio
     driver_confidence_dict = dict(zip(driver_confidence.index,driver_confidence))
 
-    dnf_by_constructor = data.groupby('CONSTRUCTOR_NAME').sum()['DNF_FLAG']
+    dnf_by_constructor = data.groupby('CONSTRUCTOR_NAME').sum(numeric_only=True)['DNF_FLAG']
     constructor_race_entered = data.groupby('CONSTRUCTOR_NAME').count()['DNF_FLAG']
     constructor_dnf_ratio = (dnf_by_constructor/constructor_race_entered)
     constructor_relaiblity = 1-constructor_dnf_ratio


### PR DESCRIPTION
after snowflake upgraded the default version of pandas, ran into some errors like:
```  TypeError: drop() takes from 1 to 2 positional arguments but 3 were given```
and 
``` TypeError: unsupported operand type(s) for +: 'datetime.date' and 'datetime.date' ```

